### PR TITLE
build: remove LDFLAGS and CPPFLAGS from libumpf.pc

### DIFF
--- a/libumpf.pc.in
+++ b/libumpf.pc.in
@@ -7,6 +7,6 @@ datadir=@datarootdir@
 Name: libumpf
 Description: Portfolio Daemon Library
 Version: @VERSION@
-Libs: @LDFLAGS@ -L${libdir} -lumpf
-Cflags: @CPPFLAGS@ -I${includedir}
+Libs: -L${libdir} -lumpf
+Cflags: -I${includedir}
 


### PR DESCRIPTION
Adding LDFLAGS seems to be wrong, maybe LIBS could
be needed.

This issue was noticed since Fedora >=23 where they used
these flags for distro builds:

  -Wl,-z,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld

Then it's not possible to compile something against libumpf
without using some special CFLAGS too ...